### PR TITLE
Implement CRUD and minimal UI for clients, trips, and bookings

### DIFF
--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -1,0 +1,4 @@
+"""CRUD package exporting resource modules."""
+from . import bookings, clients, trips
+
+__all__ = ["bookings", "clients", "trips"]

--- a/app/crud/bookings.py
+++ b/app/crud/bookings.py
@@ -1,0 +1,27 @@
+"""CRUD operations for Booking objects."""
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+
+
+def create_booking(db: Session, booking_in: schemas.BookingCreate) -> models.Booking:
+    booking = models.Booking(
+        client_id=booking_in.client_id,
+        trip_id=booking_in.trip_id,
+    )
+    db.add(booking)
+    db.commit()
+    db.refresh(booking)
+    return booking
+
+
+def get_booking(db: Session, booking_id: int) -> models.Booking | None:
+    return db.get(models.Booking, booking_id)
+
+
+def list_bookings(db: Session) -> list[models.Booking]:
+    stmt = select(models.Booking)
+    return db.execute(stmt).scalars().all()

--- a/app/crud/clients.py
+++ b/app/crud/clients.py
@@ -1,0 +1,40 @@
+"""CRUD operations for Client objects."""
+from __future__ import annotations
+
+from sqlalchemy import Select, func, or_, select
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..services.phone import normalize_phone
+
+
+def create_client(db: Session, client_in: schemas.ClientCreate) -> models.Client:
+    """Create a new client ensuring email and phone normalization."""
+    client = models.Client(
+        name=client_in.name,
+        email=client_in.email.lower(),
+        phone=client_in.phone,
+        normalized_phone=normalize_phone(client_in.phone),
+    )
+    db.add(client)
+    db.commit()
+    db.refresh(client)
+    return client
+
+
+def get_client(db: Session, client_id: int) -> models.Client | None:
+    return db.get(models.Client, client_id)
+
+
+def list_clients(db: Session, query: str | None = None) -> list[models.Client]:
+    stmt: Select[tuple[models.Client]] = select(models.Client)
+    if query:
+        pattern = f"%{query.lower()}%"
+        stmt = stmt.where(
+            or_(
+                func.lower(models.Client.name).like(pattern),
+                func.lower(models.Client.email).like(pattern),
+                models.Client.phone.like(f"%{query}%"),
+            )
+        )
+    return db.execute(stmt).scalars().all()

--- a/app/crud/trips.py
+++ b/app/crud/trips.py
@@ -1,0 +1,24 @@
+"""CRUD operations for Trip objects."""
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+
+
+def create_trip(db: Session, trip_in: schemas.TripCreate) -> models.Trip:
+    trip = models.Trip(name=trip_in.name)
+    db.add(trip)
+    db.commit()
+    db.refresh(trip)
+    return trip
+
+
+def get_trip(db: Session, trip_id: int) -> models.Trip | None:
+    return db.get(models.Trip, trip_id)
+
+
+def list_trips(db: Session) -> list[models.Trip]:
+    stmt = select(models.Trip)
+    return db.execute(stmt).scalars().all()

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,40 @@
 """Entry point for the FastAPI application."""
+from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from . import db, models, routes
 
 app = FastAPI()
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+models.Base.metadata.create_all(bind=db.engine)
+
+templates = Jinja2Templates(directory="app/templates")
 
 
-@app.get("/")
-def read_root() -> dict[str, str]:
-    """Health check endpoint."""
-    return {"status": "ok"}
+@app.get("/", response_class=HTMLResponse)
+def home(request: Request, db_session: Session = Depends(db.get_db)):
+    client_count = db_session.query(func.count(models.Client.id)).scalar() or 0
+    trip_count = db_session.query(func.count(models.Trip.id)).scalar() or 0
+    booking_count = db_session.query(func.count(models.Booking.id)).scalar() or 0
+    return templates.TemplateResponse(
+        "home.html",
+        {
+            "request": request,
+            "client_count": client_count,
+            "trip_count": trip_count,
+            "booking_count": booking_count,
+        },
+    )
+
+
+# Include routers for resources
+app.include_router(routes.clients.router)
+app.include_router(routes.trips.router)
+app.include_router(routes.bookings.router)

--- a/app/models.py
+++ b/app/models.py
@@ -1,8 +1,44 @@
 """SQLAlchemy models."""
+from __future__ import annotations
 
-from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import DeclarativeBase, relationship
 
 
 class Base(DeclarativeBase):
     """Base class for declarative models."""
     pass
+
+
+class Client(Base):
+    __tablename__ = "clients"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    email = Column(String, nullable=False, unique=True, index=True)
+    phone = Column(String, nullable=True)
+    normalized_phone = Column(String, nullable=True, unique=True, index=True)
+
+    bookings = relationship("Booking", back_populates="client")
+
+
+class Trip(Base):
+    __tablename__ = "trips"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+
+    bookings = relationship("Booking", back_populates="trip")
+
+
+class Booking(Base):
+    __tablename__ = "bookings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    client_id = Column(Integer, ForeignKey("clients.id"), nullable=False)
+    trip_id = Column(Integer, ForeignKey("trips.id"), nullable=False)
+
+    client = relationship("Client", back_populates="bookings")
+    trip = relationship("Trip", back_populates="bookings")
+
+    __table_args__ = (UniqueConstraint("client_id", "trip_id", name="uq_booking_client_trip"),)

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,0 +1,4 @@
+"""Application route modules."""
+from . import bookings, clients, trips
+
+__all__ = ["bookings", "clients", "trips"]

--- a/app/routes/bookings.py
+++ b/app/routes/bookings.py
@@ -1,0 +1,60 @@
+"""Routes for booking resources."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from .. import crud, db, schemas
+
+router = APIRouter()
+templates = Jinja2Templates(directory="app/templates")
+
+
+@router.get("/bookings", response_class=HTMLResponse)
+def list_bookings_page(request: Request, db_session: Session = Depends(db.get_db)):
+    bookings = crud.bookings.list_bookings(db_session)
+    return templates.TemplateResponse(
+        "bookings/list.html", {"request": request, "bookings": bookings}
+    )
+
+
+@router.get("/bookings/new", response_class=HTMLResponse)
+def new_booking_page(request: Request, db_session: Session = Depends(db.get_db)):
+    clients = crud.clients.list_clients(db_session)
+    trips = crud.trips.list_trips(db_session)
+    return templates.TemplateResponse(
+        "bookings/new.html",
+        {"request": request, "clients": clients, "trips": trips},
+    )
+
+
+@router.get("/bookings/{booking_id}", response_class=HTMLResponse)
+def booking_detail_page(
+    request: Request, booking_id: int, db_session: Session = Depends(db.get_db)
+):
+    booking = crud.bookings.get_booking(db_session, booking_id)
+    if not booking:
+        raise HTTPException(status_code=404, detail="Booking not found")
+    return templates.TemplateResponse(
+        "bookings/detail.html", {"request": request, "booking": booking}
+    )
+
+
+@router.post(
+    "/bookings",
+    response_model=schemas.BookingRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_booking(
+    booking_in: schemas.BookingCreate, db_session: Session = Depends(db.get_db)
+):
+    try:
+        return crud.bookings.create_booking(db_session, booking_in)
+    except IntegrityError as exc:
+        db_session.rollback()
+        raise HTTPException(
+            status_code=400, detail="Booking for this client and trip already exists"
+        ) from exc

--- a/app/routes/clients.py
+++ b/app/routes/clients.py
@@ -1,0 +1,53 @@
+"""Routes for client resources."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from .. import crud, db, schemas
+
+router = APIRouter()
+templates = Jinja2Templates(directory="app/templates")
+
+
+@router.get("/clients", response_class=HTMLResponse)
+def list_clients_page(
+    request: Request, q: str = "", db_session: Session = Depends(db.get_db)
+):
+    clients = crud.clients.list_clients(db_session, q)
+    return templates.TemplateResponse(
+        "clients/list.html", {"request": request, "clients": clients, "q": q}
+    )
+
+
+@router.get("/clients/new", response_class=HTMLResponse)
+def new_client_page(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse("clients/new.html", {"request": request})
+
+
+@router.get("/clients/{client_id}", response_class=HTMLResponse)
+def client_detail_page(
+    request: Request, client_id: int, db_session: Session = Depends(db.get_db)
+):
+    client = crud.clients.get_client(db_session, client_id)
+    if not client:
+        raise HTTPException(status_code=404, detail="Client not found")
+    return templates.TemplateResponse(
+        "clients/detail.html", {"request": request, "client": client}
+    )
+
+
+@router.post("/clients", response_model=schemas.ClientRead, status_code=status.HTTP_201_CREATED)
+def create_client(
+    client_in: schemas.ClientCreate, db_session: Session = Depends(db.get_db)
+):
+    try:
+        return crud.clients.create_client(db_session, client_in)
+    except IntegrityError as exc:
+        db_session.rollback()
+        raise HTTPException(
+            status_code=400, detail="Client with this email or phone already exists"
+        ) from exc

--- a/app/routes/trips.py
+++ b/app/routes/trips.py
@@ -1,0 +1,42 @@
+"""Routes for trip resources."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from .. import crud, db, schemas
+
+router = APIRouter()
+templates = Jinja2Templates(directory="app/templates")
+
+
+@router.get("/trips", response_class=HTMLResponse)
+def list_trips_page(request: Request, db_session: Session = Depends(db.get_db)):
+    trips = crud.trips.list_trips(db_session)
+    return templates.TemplateResponse(
+        "trips/list.html", {"request": request, "trips": trips}
+    )
+
+
+@router.get("/trips/new", response_class=HTMLResponse)
+def new_trip_page(request: Request):
+    return templates.TemplateResponse("trips/new.html", {"request": request})
+
+
+@router.get("/trips/{trip_id}", response_class=HTMLResponse)
+def trip_detail_page(
+    request: Request, trip_id: int, db_session: Session = Depends(db.get_db)
+):
+    trip = crud.trips.get_trip(db_session, trip_id)
+    if not trip:
+        raise HTTPException(status_code=404, detail="Trip not found")
+    return templates.TemplateResponse(
+        "trips/detail.html", {"request": request, "trip": trip}
+    )
+
+
+@router.post("/trips", response_model=schemas.TripRead, status_code=status.HTTP_201_CREATED)
+def create_trip(trip_in: schemas.TripCreate, db_session: Session = Depends(db.get_db)):
+    return crud.trips.create_trip(db_session, trip_in)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,9 +1,52 @@
 """Pydantic models for request and response bodies."""
+from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr
 
 
-class Item(BaseModel):
-    """Example schema."""
-    id: int
+class ClientBase(BaseModel):
     name: str
+    email: EmailStr
+    phone: str | None = None
+
+
+class ClientCreate(ClientBase):
+    pass
+
+
+class ClientRead(ClientBase):
+    id: int
+
+    class Config:
+        from_attributes = True
+
+
+class TripBase(BaseModel):
+    name: str
+
+
+class TripCreate(TripBase):
+    pass
+
+
+class TripRead(TripBase):
+    id: int
+
+    class Config:
+        from_attributes = True
+
+
+class BookingBase(BaseModel):
+    client_id: int
+    trip_id: int
+
+
+class BookingCreate(BookingBase):
+    pass
+
+
+class BookingRead(BookingBase):
+    id: int
+
+    class Config:
+        from_attributes = True

--- a/app/services/phone.py
+++ b/app/services/phone.py
@@ -1,0 +1,28 @@
+"""Utilities for working with phone numbers."""
+from __future__ import annotations
+
+import re
+
+
+def normalize_phone(phone: str | None) -> str | None:
+    """Normalize a phone number for uniqueness comparisons.
+
+    - Strip all non-digit characters.
+    - Keep the leading '+' if present on the original input.
+    - Compare based on the last seven digits which helps avoid
+      issues with country codes and formatting differences.
+
+    Returns ``None`` when no digits are present.
+    """
+    if not phone:
+        return None
+
+    phone = phone.strip()
+    plus = phone.startswith("+")
+    digits = re.sub(r"\D", "", phone)
+    if not digits:
+        return None
+
+    # Use only the last seven digits for comparisons
+    digits = digits[-7:]
+    return ("+" if plus else "") + digits

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,9 +4,15 @@
     <meta charset="UTF-8" />
     <title>Astraion Travel USB App</title>
     <link rel="stylesheet" href="/static/css/app.css" />
+    <script src="https://unpkg.com/htmx.org@1.9.9"></script>
 </head>
 <body>
-    <h1>Welcome to Astraion Travel</h1>
+    <nav>
+        <a href="/">Home</a> |
+        <a href="/clients">Clients</a> |
+        <a href="/trips">Trips</a> |
+        <a href="/bookings">Bookings</a>
+    </nav>
     {% block content %}{% endblock %}
 </body>
 </html>

--- a/app/templates/bookings/detail.html
+++ b/app/templates/bookings/detail.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Booking {{ booking.id }}</h1>
+<p>Client ID: {{ booking.client_id }}</p>
+<p>Trip ID: {{ booking.trip_id }}</p>
+<a href="/bookings">Back to list</a>
+{% endblock %}

--- a/app/templates/bookings/list.html
+++ b/app/templates/bookings/list.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Bookings</h1>
+<ul>
+{% for booking in bookings %}
+  <li>Client {{ booking.client_id }} - Trip {{ booking.trip_id }}</li>
+{% endfor %}
+</ul>
+<a href="/bookings/new">New Booking</a>
+{% endblock %}

--- a/app/templates/bookings/new.html
+++ b/app/templates/bookings/new.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>New Booking</h1>
+<form hx-post="/bookings" hx-target="#result" hx-swap="innerHTML">
+    <label>Client:
+        <select name="client_id">
+            {% for client in clients %}
+                <option value="{{ client.id }}">{{ client.name }}</option>
+            {% endfor %}
+        </select>
+    </label><br />
+    <label>Trip:
+        <select name="trip_id">
+            {% for trip in trips %}
+                <option value="{{ trip.id }}">{{ trip.name }}</option>
+            {% endfor %}
+        </select>
+    </label><br />
+    <button type="submit">Create</button>
+</form>
+<div id="result"></div>
+{% endblock %}

--- a/app/templates/clients/detail.html
+++ b/app/templates/clients/detail.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{{ client.name }}</h1>
+<p>Email: {{ client.email }}</p>
+<p>Phone: {{ client.phone }}</p>
+<a href="/clients">Back to list</a>
+{% endblock %}

--- a/app/templates/clients/list.html
+++ b/app/templates/clients/list.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Clients</h1>
+<form hx-get="/clients" hx-target="#client-list">
+    <input type="text" name="q" value="{{ q }}" placeholder="Search" />
+    <button type="submit">Search</button>
+</form>
+<div id="client-list">
+    <ul>
+    {% for client in clients %}
+        <li><a href="/clients/{{ client.id }}">{{ client.name }}</a> - {{ client.email }} - {{ client.phone }}</li>
+    {% endfor %}
+    </ul>
+</div>
+<a href="/clients/new">New Client</a>
+{% endblock %}

--- a/app/templates/clients/new.html
+++ b/app/templates/clients/new.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>New Client</h1>
+<form hx-post="/clients" hx-target="#result" hx-swap="innerHTML">
+    <label>Name: <input type="text" name="name" /></label><br />
+    <label>Email: <input type="email" name="email" /></label><br />
+    <label>Phone: <input type="text" name="phone" /></label><br />
+    <button type="submit">Create</button>
+</form>
+<div id="result"></div>
+{% endblock %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Dashboard</h1>
+<ul>
+    <li>Clients: {{ client_count }}</li>
+    <li>Trips: {{ trip_count }}</li>
+    <li>Bookings: {{ booking_count }}</li>
+</ul>
+{% endblock %}

--- a/app/templates/trips/detail.html
+++ b/app/templates/trips/detail.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{{ trip.name }}</h1>
+<a href="/trips">Back to list</a>
+{% endblock %}

--- a/app/templates/trips/list.html
+++ b/app/templates/trips/list.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Trips</h1>
+<ul>
+{% for trip in trips %}
+  <li><a href="/trips/{{ trip.id }}">{{ trip.name }}</a></li>
+{% endfor %}
+</ul>
+<a href="/trips/new">New Trip</a>
+{% endblock %}

--- a/app/templates/trips/new.html
+++ b/app/templates/trips/new.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>New Trip</h1>
+<form hx-post="/trips" hx-target="#result" hx-swap="innerHTML">
+    <label>Name: <input type="text" name="name" /></label><br />
+    <button type="submit">Create</button>
+</form>
+<div id="result"></div>
+{% endblock %}

--- a/tests/test_bookings.py
+++ b/tests/test_bookings.py
@@ -1,0 +1,42 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from app import db, models
+from app.main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    models.Base.metadata.drop_all(bind=db.engine)
+    models.Base.metadata.create_all(bind=db.engine)
+    yield
+    models.Base.metadata.drop_all(bind=db.engine)
+
+
+def create_client(name: str, email: str, phone: str) -> dict:
+    response = client.post(
+        "/clients", json={"name": name, "email": email, "phone": phone}
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def create_trip(name: str) -> dict:
+    response = client.post("/trips", json={"name": name})
+    assert response.status_code == 201
+    return response.json()
+
+
+def test_unique_booking():
+    cl = create_client("Alice", "alice@example.com", "+1 (555) 123-4567")
+    tr = create_trip("Trip 1")
+    r1 = client.post(
+        "/bookings", json={"client_id": cl["id"], "trip_id": tr["id"]}
+    )
+    assert r1.status_code == 201
+    r2 = client.post(
+        "/bookings", json={"client_id": cl["id"], "trip_id": tr["id"]}
+    )
+    assert r2.status_code == 400

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,0 +1,41 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from app import db, models
+from app.main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    models.Base.metadata.drop_all(bind=db.engine)
+    models.Base.metadata.create_all(bind=db.engine)
+    yield
+    models.Base.metadata.drop_all(bind=db.engine)
+
+
+def test_unique_email():
+    r1 = client.post(
+        "/clients",
+        json={"name": "Alice", "email": "Test@Example.com", "phone": "+1 (555) 123-4567"},
+    )
+    assert r1.status_code == 201
+    r2 = client.post(
+        "/clients",
+        json={"name": "Bob", "email": "TEST@example.com", "phone": "+1 (555) 765-4321"},
+    )
+    assert r2.status_code == 400
+
+
+def test_unique_phone():
+    r1 = client.post(
+        "/clients",
+        json={"name": "Alice", "email": "a1@example.com", "phone": "+1 (555) 123-4567"},
+    )
+    assert r1.status_code == 201
+    r2 = client.post(
+        "/clients",
+        json={"name": "Bob", "email": "a2@example.com", "phone": "+1-555-123-4567"},
+    )
+    assert r2.status_code == 400


### PR DESCRIPTION
## Summary
- add phone normalization helper
- implement SQLAlchemy models, CRUD modules, and routers for clients, trips, and bookings
- create Jinja2 templates and simple dashboard
- include tests for unique constraints on emails, phones, and bookings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68ab84d96cfc83309ed7e041fe242ace