### PR TITLE
Add booking UI enhancements and automated backups

### DIFF
--- a/app/crud/bookings.py
+++ b/app/crud/bookings.py
@@ -25,3 +25,10 @@ def get_booking(db: Session, booking_id: int) -> models.Booking | None:
 def list_bookings(db: Session) -> list[models.Booking]:
     stmt = select(models.Booking)
     return db.execute(stmt).scalars().all()
+
+
+def delete_booking(db: Session, booking_id: int) -> None:
+    booking = db.get(models.Booking, booking_id)
+    if booking:
+        db.delete(booking)
+        db.commit()

--- a/app/main.py
+++ b/app/main.py
@@ -2,13 +2,15 @@
 from __future__ import annotations
 
 from fastapi import Depends, FastAPI, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, PlainTextResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from . import db, models, routes
+from .services import backups
+from apscheduler.schedulers.background import BackgroundScheduler
 
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="static"), name="static")
@@ -16,6 +18,11 @@ app.mount("/static", StaticFiles(directory="static"), name="static")
 models.Base.metadata.create_all(bind=db.engine)
 
 templates = Jinja2Templates(directory="app/templates")
+
+
+scheduler = BackgroundScheduler()
+scheduler.add_job(backups.backup_db, "cron", hour=2, minute=30)
+scheduler.start()
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -32,6 +39,12 @@ def home(request: Request, db_session: Session = Depends(db.get_db)):
             "booking_count": booking_count,
         },
     )
+
+
+@app.post("/admin/backup-now", response_class=PlainTextResponse)
+def backup_now() -> str:
+    backups.backup_db()
+    return "Backup created"
 
 
 # Include routers for resources

--- a/app/routes/bookings.py
+++ b/app/routes/bookings.py
@@ -22,12 +22,23 @@ def list_bookings_page(request: Request, db_session: Session = Depends(db.get_db
 
 
 @router.get("/bookings/new", response_class=HTMLResponse)
-def new_booking_page(request: Request, db_session: Session = Depends(db.get_db)):
+def new_booking_page(
+    request: Request,
+    client_id: int | None = None,
+    trip_id: int | None = None,
+    db_session: Session = Depends(db.get_db),
+):
     clients = crud.clients.list_clients(db_session)
     trips = crud.trips.list_trips(db_session)
     return templates.TemplateResponse(
         "bookings/new.html",
-        {"request": request, "clients": clients, "trips": trips},
+        {
+            "request": request,
+            "clients": clients,
+            "trips": trips,
+            "client_id": client_id,
+            "trip_id": trip_id,
+        },
     )
 
 

--- a/app/routes/clients.py
+++ b/app/routes/clients.py
@@ -1,7 +1,7 @@
 """Routes for client resources."""
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status, Form
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.exc import IntegrityError
@@ -36,8 +36,57 @@ def client_detail_page(
     client = crud.clients.get_client(db_session, client_id)
     if not client:
         raise HTTPException(status_code=404, detail="Client not found")
+    trips = crud.trips.list_trips(db_session)
     return templates.TemplateResponse(
-        "clients/detail.html", {"request": request, "client": client}
+        "clients/detail.html", {"request": request, "client": client, "trips": trips}
+    )
+
+
+@router.get("/clients/{client_id}/bookings", response_class=HTMLResponse)
+def client_bookings(
+    request: Request, client_id: int, db_session: Session = Depends(db.get_db)
+):
+    client = crud.clients.get_client(db_session, client_id)
+    if not client:
+        raise HTTPException(status_code=404, detail="Client not found")
+    trips = crud.trips.list_trips(db_session)
+    return templates.TemplateResponse(
+        "clients/_bookings.html", {"request": request, "client": client, "trips": trips}
+    )
+
+
+@router.post("/clients/{client_id}/bookings", response_class=HTMLResponse)
+def add_client_booking(
+    request: Request,
+    client_id: int,
+    trip_id: int = Form(...),
+    db_session: Session = Depends(db.get_db),
+):
+    try:
+        crud.bookings.create_booking(
+            db_session, schemas.BookingCreate(client_id=client_id, trip_id=trip_id)
+        )
+    except IntegrityError:
+        db_session.rollback()
+    client = crud.clients.get_client(db_session, client_id)
+    trips = crud.trips.list_trips(db_session)
+    return templates.TemplateResponse(
+        "clients/_bookings.html", {"request": request, "client": client, "trips": trips}
+    )
+
+
+@router.delete("/clients/{client_id}/bookings/{booking_id}", response_class=HTMLResponse)
+def delete_client_booking(
+    request: Request,
+    client_id: int,
+    booking_id: int,
+    db_session: Session = Depends(db.get_db),
+):
+    crud.bookings.delete_booking(db_session, booking_id)
+    client = crud.clients.get_client(db_session, client_id)
+    trips = crud.trips.list_trips(db_session)
+    return templates.TemplateResponse(
+        "clients/_bookings.html", {"request": request, "client": client, "trips": trips}
     )
 
 

--- a/app/services/backups.py
+++ b/app/services/backups.py
@@ -1,0 +1,26 @@
+"""Database backup utilities."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import shutil
+
+DB_PATH = Path("data/astraion.db")
+BACKUP_DIR = Path("data/backups")
+
+
+def backup_db(db_path: Path = DB_PATH, backup_dir: Path = BACKUP_DIR) -> Path:
+    """Copy the SQLite database to a timestamped backup file.
+
+    Args:
+        db_path: Path to the SQLite database file.
+        backup_dir: Directory where backups should be stored.
+
+    Returns:
+        Path to the created backup file.
+    """
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M")
+    backup_path = backup_dir / f"{timestamp}.db"
+    shutil.copy(db_path, backup_path)
+    return backup_path

--- a/app/templates/bookings/new.html
+++ b/app/templates/bookings/new.html
@@ -5,14 +5,14 @@
     <label>Client:
         <select name="client_id">
             {% for client in clients %}
-                <option value="{{ client.id }}">{{ client.name }}</option>
+                <option value="{{ client.id }}" {% if client_id == client.id %}selected{% endif %}>{{ client.name }}</option>
             {% endfor %}
         </select>
     </label><br />
     <label>Trip:
         <select name="trip_id">
             {% for trip in trips %}
-                <option value="{{ trip.id }}">{{ trip.name }}</option>
+                <option value="{{ trip.id }}" {% if trip_id == trip.id %}selected{% endif %}>{{ trip.name }}</option>
             {% endfor %}
         </select>
     </label><br />

--- a/app/templates/clients/_bookings.html
+++ b/app/templates/clients/_bookings.html
@@ -1,0 +1,20 @@
+<ul>
+    {% for booking in client.bookings %}
+    <li>
+        {{ booking.trip.name }}
+        <form hx-delete="/clients/{{ client.id }}/bookings/{{ booking.id }}" hx-target="#bookings" hx-swap="outerHTML" style="display:inline">
+            <button type="submit">Remove</button>
+        </form>
+    </li>
+    {% else %}
+    <li>No bookings</li>
+    {% endfor %}
+</ul>
+<form hx-post="/clients/{{ client.id }}/bookings" hx-target="#bookings" hx-swap="outerHTML">
+    <select name="trip_id">
+        {% for trip in trips %}
+        <option value="{{ trip.id }}">{{ trip.name }}</option>
+        {% endfor %}
+    </select>
+    <button type="submit">Add booking</button>
+</form>

--- a/app/templates/clients/detail.html
+++ b/app/templates/clients/detail.html
@@ -3,5 +3,10 @@
 <h1>{{ client.name }}</h1>
 <p>Email: {{ client.email }}</p>
 <p>Phone: {{ client.phone }}</p>
+<h2>Bookings</h2>
+<div id="bookings">
+    {% include "clients/_bookings.html" %}
+</div>
+<a href="/bookings/new?client_id={{ client.id }}">Add booking</a>
 <a href="/clients">Back to list</a>
 {% endblock %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -6,4 +6,8 @@
     <li>Trips: {{ trip_count }}</li>
     <li>Bookings: {{ booking_count }}</li>
 </ul>
+<form hx-post="/admin/backup-now" hx-target="#backup-result" hx-swap="innerHTML">
+    <button type="submit">Backup now</button>
+</form>
+<div id="backup-result"></div>
 {% endblock %}

--- a/app/templates/trips/detail.html
+++ b/app/templates/trips/detail.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>{{ trip.name }}</h1>
+<a href="/bookings/new?trip_id={{ trip.id }}">Add booking</a>
 <a href="/trips">Back to list</a>
 {% endblock %}

--- a/tests/test_backups.py
+++ b/tests/test_backups.py
@@ -1,0 +1,17 @@
+import re
+
+from app.services import backups
+
+
+def test_backup_db_creates_timestamped_file(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    db_file = data_dir / "astraion.db"
+    db_file.write_text("content")
+
+    backup_dir = data_dir / "backups"
+    result = backups.backup_db(db_path=db_file, backup_dir=backup_dir)
+
+    assert result.exists()
+    assert result.parent == backup_dir
+    assert re.match(r"\d{8}-\d{4}\.db", result.name)


### PR DESCRIPTION
## Summary
- Display client bookings with HTMX add/remove controls and add booking links from client and trip pages
- Introduce database backup service with nightly APScheduler job and manual trigger endpoint
- Cover backup utility with tests

## Testing
- ⚠️ `pytest -q` *(missing fastapi/sqlalchemy dependencies)*
- ✅ `pytest tests/test_backups.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab892dca908330aa660024c1014d85