### PR TITLE
Add PyInstaller packaging and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install . pyinstaller
+      - name: Build executable
+        run: pyinstaller packaging/build.spec
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/Astraion.exe
+          asset_name: Astraion.exe
+          asset_content_type: application/octet-stream
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,14 +4,15 @@ __pycache__/
 *.egg-info/
 *.egg
 .build/
-build/
-dist/
+/build/
+/dist/
 .eggs/
 .env
 .venv
 venv/
 .envrc
 *.sqlite3
+*.exe
 
 # IDEs
 .idea/

--- a/Start.bat
+++ b/Start.bat
@@ -1,0 +1,6 @@
+@echo off
+set PORT=8787
+start "" "%~dp0Astraion.exe" --db "%~dp0data\astraion.db" --port %PORT%
+timeout /t 2 /nobreak > NUL
+start "" "http://localhost:%PORT%"
+

--- a/packaging/build.spec
+++ b/packaging/build.spec
@@ -1,0 +1,58 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+"""PyInstaller spec for one-file Astraion executable.
+
+This configuration bundles the FastAPI templates and static assets and
+directs PyInstaller to use a local ``logs`` directory for its runtime
+extraction and logging.
+"""
+
+import os
+
+block_cipher = None
+
+# Data files: include Jinja templates and static assets.
+datas = [
+    ("app/templates", "app/templates"),
+    ("static", "static"),
+]
+
+# Ensure a logs directory exists alongside the executable.
+if not os.path.exists("logs"):
+    os.makedirs("logs")
+
+a = Analysis(
+    ["app/main.py"],
+    pathex=[],
+    binaries=[],
+    datas=datas,
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name="Astraion",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir="logs",
+    console=True,
+    icon=None,
+)
+


### PR DESCRIPTION
## Summary
- package app with PyInstaller one-file build including templates and static assets
- add Start.bat launcher for running the compiled executable and opening the browser
- configure GitHub Actions workflow to build on tag and upload the EXE to a release
- update .gitignore to exclude build outputs and executables

## Testing
- `pip install pre-commit` *(fails: Cannot connect to proxy (403))*
- `pip install .` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab9ade4fbc8330b3ba8e4d132676f9