### PR TITLE
Add scaffolding for vehicles, maintenance, and reminders

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,3 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = sqlite:///./app.db

--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -1,4 +1,4 @@
 """CRUD package exporting resource modules."""
-from . import bookings, clients, trips
+from . import bookings, clients, trips, vehicles, maintenance, reminders
 
-__all__ = ["bookings", "clients", "trips"]
+__all__ = ["bookings", "clients", "trips", "vehicles", "maintenance", "reminders"]

--- a/app/crud/maintenance.py
+++ b/app/crud/maintenance.py
@@ -1,0 +1,28 @@
+"""CRUD operations for Maintenance objects."""
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+
+
+def create_maintenance(db: Session, maintenance_in: schemas.MaintenanceCreate) -> models.Maintenance:
+    record = models.Maintenance(
+        vehicle_id=maintenance_in.vehicle_id,
+        kind=maintenance_in.kind,
+        due_date=maintenance_in.due_date,
+        completed_at=maintenance_in.completed_at,
+        notes=maintenance_in.notes,
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+def list_maintenance(db: Session, vehicle_id: str | None = None) -> list[models.Maintenance]:
+    stmt = select(models.Maintenance)
+    if vehicle_id:
+        stmt = stmt.where(models.Maintenance.vehicle_id == vehicle_id)
+    return db.execute(stmt).scalars().all()

--- a/app/crud/reminders.py
+++ b/app/crud/reminders.py
@@ -1,0 +1,29 @@
+"""CRUD operations for Reminder objects."""
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+
+
+def create_reminder(db: Session, reminder_in: schemas.ReminderCreate) -> models.Reminder:
+    reminder = models.Reminder(
+        scope=reminder_in.scope,
+        ref_id=reminder_in.ref_id,
+        title=reminder_in.title,
+        due_date=reminder_in.due_date,
+        assigned_role=reminder_in.assigned_role,
+        done_at=reminder_in.done_at,
+    )
+    db.add(reminder)
+    db.commit()
+    db.refresh(reminder)
+    return reminder
+
+
+def list_reminders(db: Session, scope: str | None = None) -> list[models.Reminder]:
+    stmt = select(models.Reminder)
+    if scope:
+        stmt = stmt.where(models.Reminder.scope == scope)
+    return db.execute(stmt).scalars().all()

--- a/app/crud/vehicles.py
+++ b/app/crud/vehicles.py
@@ -1,0 +1,25 @@
+"""CRUD operations for Vehicle objects."""
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+
+
+def create_vehicle(db: Session, vehicle_in: schemas.VehicleCreate) -> models.Vehicle:
+    vehicle = models.Vehicle(
+        plate=vehicle_in.plate,
+        model=vehicle_in.model,
+        year=vehicle_in.year,
+        notes=vehicle_in.notes,
+    )
+    db.add(vehicle)
+    db.commit()
+    db.refresh(vehicle)
+    return vehicle
+
+
+def list_vehicles(db: Session) -> list[models.Vehicle]:
+    stmt = select(models.Vehicle)
+    return db.execute(stmt).scalars().all()

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -55,3 +55,64 @@ class BookingRead(BookingBase):
 
     class Config:
         from_attributes = True
+
+
+class VehicleBase(BaseModel):
+    plate: str
+    model: str
+    year: int | None = None
+    notes: str | None = None
+
+
+class VehicleCreate(VehicleBase):
+    pass
+
+
+class VehicleRead(VehicleBase):
+    id: str
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class MaintenanceBase(BaseModel):
+    vehicle_id: str
+    kind: str
+    due_date: date
+    notes: str | None = None
+    completed_at: datetime | None = None
+
+
+class MaintenanceCreate(MaintenanceBase):
+    pass
+
+
+class MaintenanceRead(MaintenanceBase):
+    id: str
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class ReminderBase(BaseModel):
+    scope: str
+    ref_id: str | None = None
+    title: str
+    due_date: date
+    assigned_role: str | None = None
+    done_at: datetime | None = None
+
+
+class ReminderCreate(ReminderBase):
+    pass
+
+
+class ReminderRead(ReminderBase):
+    id: str
+
+    class Config:
+        from_attributes = True

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app import models
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = models.Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/versions/0001_add_vehicle_maintenance_reminder_tables.py
+++ b/migrations/versions/0001_add_vehicle_maintenance_reminder_tables.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "vehicles",
+        sa.Column("id", sa.String(), primary_key=True, nullable=False),
+        sa.Column("plate", sa.String(), nullable=False),
+        sa.Column("model", sa.String(), nullable=False),
+        sa.Column("year", sa.Integer(), nullable=True),
+        sa.Column("notes", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("plate"),
+    )
+
+    op.create_table(
+        "maintenance",
+        sa.Column("id", sa.String(), primary_key=True, nullable=False),
+        sa.Column("vehicle_id", sa.String(), sa.ForeignKey("vehicles.id"), nullable=False),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column("due_date", sa.Date(), nullable=False),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.Column("notes", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "reminders",
+        sa.Column("id", sa.String(), primary_key=True, nullable=False),
+        sa.Column("scope", sa.String(), nullable=False),
+        sa.Column("ref_id", sa.String(), nullable=True),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("due_date", sa.Date(), nullable=False),
+        sa.Column("assigned_role", sa.String(), nullable=True),
+        sa.Column("done_at", sa.DateTime(), nullable=True),
+        sa.CheckConstraint("scope IN ('global','vehicle','trip','client')", name="ck_reminder_scope"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("reminders")
+    op.drop_table("maintenance")
+    op.drop_table("vehicles")

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,39 @@
+import pytest
+from sqlalchemy import inspect
+from datetime import date
+
+from app import db, models, schemas
+from app.crud import vehicles, maintenance
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    models.Base.metadata.drop_all(bind=db.engine)
+    models.Base.metadata.create_all(bind=db.engine)
+    yield
+    models.Base.metadata.drop_all(bind=db.engine)
+
+
+def test_maintenance_create_list():
+    inspector = inspect(db.engine)
+    assert inspector.has_table("maintenance")
+
+    session = db.SessionLocal()
+    try:
+        vehicle = vehicles.create_vehicle(
+            session,
+            schemas.VehicleCreate(plate="ABC123", model="Ford", year=2020),
+        )
+        maintenance.create_maintenance(
+            session,
+            schemas.MaintenanceCreate(
+                vehicle_id=vehicle.id,
+                kind="oil",
+                due_date=date(2024, 1, 1),
+            ),
+        )
+        records = maintenance.list_maintenance(session, vehicle_id=vehicle.id)
+        assert len(records) == 1
+        assert records[0].kind == "oil"
+    finally:
+        session.close()

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -1,0 +1,36 @@
+import pytest
+from sqlalchemy import inspect
+from datetime import date
+
+from app import db, models, schemas
+from app.crud import reminders
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    models.Base.metadata.drop_all(bind=db.engine)
+    models.Base.metadata.create_all(bind=db.engine)
+    yield
+    models.Base.metadata.drop_all(bind=db.engine)
+
+
+def test_reminder_create_list():
+    inspector = inspect(db.engine)
+    assert inspector.has_table("reminders")
+
+    session = db.SessionLocal()
+    try:
+        reminders.create_reminder(
+            session,
+            schemas.ReminderCreate(
+                scope="global",
+                title="Check",
+                due_date=date(2024, 1, 1),
+                assigned_role="admin",
+            ),
+        )
+        all_reminders = reminders.list_reminders(session)
+        assert len(all_reminders) == 1
+        assert all_reminders[0].scope == "global"
+    finally:
+        session.close()

--- a/tests/test_vehicles.py
+++ b/tests/test_vehicles.py
@@ -1,0 +1,35 @@
+import pytest
+from sqlalchemy import inspect
+
+from app import db, models, schemas
+from app.crud import vehicles
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    models.Base.metadata.drop_all(bind=db.engine)
+    models.Base.metadata.create_all(bind=db.engine)
+    yield
+    models.Base.metadata.drop_all(bind=db.engine)
+
+
+def test_vehicle_create_list():
+    inspector = inspect(db.engine)
+    assert inspector.has_table("vehicles")
+
+    session = db.SessionLocal()
+    try:
+        vehicles.create_vehicle(
+            session,
+            schemas.VehicleCreate(plate="ABC123", model="Ford", year=2020, notes="A"),
+        )
+        vehicles.create_vehicle(
+            session,
+            schemas.VehicleCreate(plate="XYZ789", model="Toyota", year=2021),
+        )
+        all_vehicles = vehicles.list_vehicles(session)
+        assert len(all_vehicles) == 2
+        plates = {v.plate for v in all_vehicles}
+        assert {"ABC123", "XYZ789"} == plates
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
- introduce Vehicle, Maintenance, and Reminder models with Alembic migration
- provide basic CRUD services for the new models
- add unit tests ensuring create and list operations work for each table

## Testing
- `pytest` *(fails: command not found)*
- `pip install --break-system-packages pytest` *(fails: Could not find a version that satisfies the requirement)*
- `pip install --break-system-packages alembic` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9f21541883308fbee438fa082218