### PR TITLE
Add CSV exports, timelines, and branding

### DIFF
--- a/app/routes/clients.py
+++ b/app/routes/clients.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+import csv
+import io
+
 from .. import crud, db, schemas
-from ..services import dedupe
+from ..services import audit, dedupe
 
 router = APIRouter()
 templates = Jinja2Templates(directory="app/templates")
@@ -37,8 +40,26 @@ def client_detail_page(
     if not client:
         raise HTTPException(status_code=404, detail="Client not found")
     trips = crud.trips.list_trips(db_session)
+    logs = audit.get_logs(db_session, entity="client", entity_id=client_id)
     return templates.TemplateResponse(
-        "clients/detail.html", {"request": request, "client": client, "trips": trips}
+        "clients/detail.html", {"request": request, "client": client, "trips": trips, "logs": logs}
+    )
+
+
+@router.get("/clients/export")
+def export_clients(db_session: Session = Depends(db.get_db)):
+    clients = crud.clients.list_clients(db_session)
+    stream = io.StringIO()
+    writer = csv.writer(stream)
+    writer.writerow(["ID", "Name", "Email", "Phone"])
+    for client in clients:
+        writer.writerow([client.id, client.name, client.email, client.phone])
+    stream.seek(0)
+    headers = {"Content-Disposition": "attachment; filename=clients.csv"}
+    return StreamingResponse(
+        iter([stream.getvalue()]),
+        media_type="text/csv",
+        headers=headers,
     )
 
 

--- a/app/routes/trips.py
+++ b/app/routes/trips.py
@@ -2,11 +2,15 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
+import csv
+import io
+
 from .. import crud, db, schemas
+from ..services import audit
 
 router = APIRouter()
 templates = Jinja2Templates(directory="app/templates")
@@ -32,11 +36,29 @@ def trip_detail_page(
     trip = crud.trips.get_trip(db_session, trip_id)
     if not trip:
         raise HTTPException(status_code=404, detail="Trip not found")
+    logs = audit.get_logs(db_session, entity="trip", entity_id=trip_id)
     return templates.TemplateResponse(
-        "trips/detail.html", {"request": request, "trip": trip}
+        "trips/detail.html", {"request": request, "trip": trip, "logs": logs}
     )
 
 
 @router.post("/trips", response_model=schemas.TripRead, status_code=status.HTTP_201_CREATED)
 def create_trip(trip_in: schemas.TripCreate, db_session: Session = Depends(db.get_db)):
     return crud.trips.create_trip(db_session, trip_in)
+
+
+@router.get("/trips/export")
+def export_trips(db_session: Session = Depends(db.get_db)):
+    trips = crud.trips.list_trips(db_session)
+    stream = io.StringIO()
+    writer = csv.writer(stream)
+    writer.writerow(["ID", "Name"])
+    for trip in trips:
+        writer.writerow([trip.id, trip.name])
+    stream.seek(0)
+    headers = {"Content-Disposition": "attachment; filename=trips.csv"}
+    return StreamingResponse(
+        iter([stream.getvalue()]),
+        media_type="text/csv",
+        headers=headers,
+    )

--- a/app/services/audit.py
+++ b/app/services/audit.py
@@ -1,6 +1,7 @@
 """Audit logging utilities."""
 from __future__ import annotations
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from .. import models
@@ -29,3 +30,13 @@ def log_action(
     )
     db.add(entry)
     return entry
+
+
+def get_logs(db: Session, *, entity: str, entity_id: int) -> list[models.AuditLog]:
+    """Fetch audit log entries for a specific entity."""
+    stmt = (
+        select(models.AuditLog)
+        .where(models.AuditLog.entity == entity, models.AuditLog.entity_id == entity_id)
+        .order_by(models.AuditLog.timestamp.desc())
+    )
+    return db.execute(stmt).scalars().all()

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,6 +8,7 @@
 </head>
 <body>
     <nav>
+        <span class="logo">🧭</span>
         <a href="/">Home</a> |
         <a href="/clients">Clients</a> |
         <a href="/trips">Trips</a> |

--- a/app/templates/clients/detail.html
+++ b/app/templates/clients/detail.html
@@ -3,10 +3,25 @@
 <h1>{{ client.name }}</h1>
 <p>Email: {{ client.email }}</p>
 <p>Phone: {{ client.phone }}</p>
-<h2>Bookings</h2>
-<div id="bookings">
-    {% include "clients/_bookings.html" %}
+
+<div class="card">
+    <h2>Bookings</h2>
+    <div id="bookings">
+        {% include "clients/_bookings.html" %}
+    </div>
+    <a href="/bookings/new?client_id={{ client.id }}">Add booking</a>
 </div>
-<a href="/bookings/new?client_id={{ client.id }}">Add booking</a>
+
+<div class="card">
+    <h2>Timeline</h2>
+    <ul class="timeline">
+        {% for log in logs %}
+            <li>{{ log.timestamp }} - {{ log.action }}</li>
+        {% else %}
+            <li>No activity recorded.</li>
+        {% endfor %}
+    </ul>
+</div>
+
 <a href="/clients">Back to list</a>
 {% endblock %}

--- a/app/templates/clients/list.html
+++ b/app/templates/clients/list.html
@@ -5,12 +5,12 @@
     <input type="text" name="q" value="{{ q }}" placeholder="Search" />
     <button type="submit">Search</button>
 </form>
-<div id="client-list">
+<div class="card" id="client-list">
     <ul>
     {% for client in clients %}
         <li><a href="/clients/{{ client.id }}">{{ client.name }}</a> - {{ client.email }} - {{ client.phone }}</li>
     {% endfor %}
     </ul>
 </div>
-<a href="/clients/new">New Client</a>
+<a href="/clients/new">New Client</a> | <a href="/clients/export">Export to Excel</a>
 {% endblock %}

--- a/app/templates/clients/merge.html
+++ b/app/templates/clients/merge.html
@@ -1,29 +1,23 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Merge Clients</title>
-</head>
-<body>
-<h1>Potential duplicate clients</h1>
-<div>
-    <h2>New Client</h2>
-    <ul>
-        <li>Name: {{ candidate.name }}</li>
-        <li>Email: {{ candidate.email }}</li>
-        <li>Phone: {{ candidate.phone }}</li>
-        <li>DOB: {{ candidate.dob }}</li>
-    </ul>
+<div class="card">
+    <h2>Potential duplicate clients</h2>
+    <div>
+        <strong>New Client</strong>
+        <ul>
+            <li>Name: {{ candidate.name }}</li>
+            <li>Email: {{ candidate.email }}</li>
+            <li>Phone: {{ candidate.phone }}</li>
+            <li>DOB: {{ candidate.dob }}</li>
+        </ul>
+    </div>
+    {% for match, score in matches %}
+    <div>
+        <strong>Existing Client ({{ (score*100)|round(2) }}% match)</strong>
+        <ul>
+            <li>Name: {{ match.name }}</li>
+            <li>Email: {{ match.email }}</li>
+            <li>Phone: {{ match.phone }}</li>
+            <li>DOB: {{ match.dob }}</li>
+        </ul>
+    </div>
+    {% endfor %}
 </div>
-{% for match, score in matches %}
-<div>
-    <h2>Existing Client ({{ (score*100)|round(2) }}% match)</h2>
-    <ul>
-        <li>Name: {{ match.name }}</li>
-        <li>Email: {{ match.email }}</li>
-        <li>Phone: {{ match.phone }}</li>
-        <li>DOB: {{ match.dob }}</li>
-    </ul>
-</div>
-{% endfor %}
-</body>
-</html>

--- a/app/templates/clients/new.html
+++ b/app/templates/clients/new.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>New Client</h1>
+<div id="result"></div>
 <form hx-post="/clients" hx-target="#result" hx-swap="innerHTML">
     <label>Name: <input type="text" name="name" /></label><br />
     <label>Email: <input type="email" name="email" /></label><br />
     <label>Phone: <input type="text" name="phone" /></label><br />
     <button type="submit">Create</button>
 </form>
-<div id="result"></div>
 {% endblock %}

--- a/app/templates/trips/detail.html
+++ b/app/templates/trips/detail.html
@@ -2,5 +2,15 @@
 {% block content %}
 <h1>{{ trip.name }}</h1>
 <a href="/bookings/new?trip_id={{ trip.id }}">Add booking</a>
+<div class="card">
+    <h2>Timeline</h2>
+    <ul class="timeline">
+        {% for log in logs %}
+            <li>{{ log.timestamp }} - {{ log.action }}</li>
+        {% else %}
+            <li>No activity recorded.</li>
+        {% endfor %}
+    </ul>
+</div>
 <a href="/trips">Back to list</a>
 {% endblock %}

--- a/app/templates/trips/list.html
+++ b/app/templates/trips/list.html
@@ -1,10 +1,12 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Trips</h1>
+<div class="card">
 <ul>
 {% for trip in trips %}
   <li><a href="/trips/{{ trip.id }}">{{ trip.name }}</a></li>
 {% endfor %}
 </ul>
-<a href="/trips/new">New Trip</a>
+</div>
+<a href="/trips/new">New Trip</a> | <a href="/trips/export">Export to Excel</a>
 {% endblock %}

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,4 +1,39 @@
+:root {
+    --color-deep-blue: #003366;
+    --color-teal: #008080;
+    --color-sand: #f4e1c1;
+}
+
 body {
     font-family: Arial, sans-serif;
     margin: 2rem;
+    background-color: var(--color-sand);
+    color: var(--color-deep-blue);
+}
+
+a {
+    color: var(--color-teal);
+}
+
+.card {
+    background: #fff;
+    border-radius: 8px;
+    padding: 1rem;
+    margin-bottom: 1rem;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.timeline {
+    list-style: none;
+    padding: 0;
+}
+
+.timeline li {
+    border-left: 4px solid var(--color-teal);
+    padding-left: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+nav .logo {
+    margin-right: 0.5rem;
 }

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,30 @@
+import pytest
+import pytest
+from fastapi.testclient import TestClient
+
+from app import db, models
+from app.main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    models.Base.metadata.drop_all(bind=db.engine)
+    models.Base.metadata.create_all(bind=db.engine)
+    yield
+    models.Base.metadata.drop_all(bind=db.engine)
+
+
+def test_client_export():
+    client.post("/clients", json={"name": "Alice", "email": "a@example.com", "phone": "123"})
+    r = client.get("/clients/export")
+    assert r.status_code == 200
+    assert "text/csv" in r.headers["content-type"]
+
+
+def test_trip_export():
+    client.post("/trips", json={"name": "Trip"})
+    r = client.get("/trips/export")
+    assert r.status_code == 200
+    assert "text/csv" in r.headers["content-type"]


### PR DESCRIPTION
## Summary
- add downloadable CSV export for client and trip lists
- show audit-log timelines on client and trip detail pages
- apply branded styling and duplicate client warning banner

## Testing
- `ruff .` *(fails: command not found)*
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68aba1564698833089bf12ea361e7920