### PR TITLE
Add Astraion Travel styling and auth templates

### DIFF
--- a/app/templates/auth/agent_dashboard.html
+++ b/app/templates/auth/agent_dashboard.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="card">
+  <h2>Agent Dashboard</h2>
+  <p>Manage client itineraries and upcoming adventures here.</p>
+</div>
+{% endblock %}
+

--- a/app/templates/auth/ceo_dashboard.html
+++ b/app/templates/auth/ceo_dashboard.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="card">
+  <h2>CEO Dashboard</h2>
+  <p>Overview of agency performance and strategic planning.</p>
+</div>
+{% endblock %}
+

--- a/app/templates/auth/client_dashboard.html
+++ b/app/templates/auth/client_dashboard.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="card">
+  <h2>Client Dashboard</h2>
+  <p>Your personal itineraries and bookings will appear here.</p>
+</div>
+{% endblock %}
+

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="card">
+  <h2>Login</h2>
+  <form>
+    <label for="username">Username</label>
+    <input id="username" name="username" type="text" />
+
+    <label for="password">Password</label>
+    <input id="password" name="password" type="password" />
+
+    <label for="role">Sign in as</label>
+    <select id="role" name="role">
+      <option value="client">Client</option>
+      <option value="agent">Agent</option>
+      <option value="ceo">CEO</option>
+    </select>
+
+    <button class="btn" type="submit">Login</button>
+  </form>
+</div>
+{% endblock %}
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,17 +8,21 @@
   <script src="https://unpkg.com/htmx.org@1.9.12"></script>
 </head>
 <body>
-  <header class="container">
-    <nav class="nav">
-      <a href="/">Home</a> |
-      <a href="/clients">Clients</a> |
-      <a href="/trips">Trips</a> |
-      <a href="/bookings">Bookings</a>
-      <form style="display:inline;margin-left:1rem;" action="/admin/backup-now" method="post">
-        <button type="submit">Backup now</button>
-      </form>
-    </nav>
-    <hr/>
+  <header>
+    <div class="container">
+      <nav class="nav">
+        <a class="logo" href="/"><span class="icon icon-compass"></span> Astraion Travel</a>
+        <div class="nav-links">
+          <a href="/clients">Clients</a>
+          <a href="/trips">Trips</a>
+          <a href="/bookings">Bookings</a>
+          <a href="/login">Login</a>
+          <form action="/admin/backup-now" method="post" style="display:inline">
+            <button class="btn" type="submit">Backup</button>
+          </form>
+        </div>
+      </nav>
+    </div>
   </header>
   <main class="container">
     {% block content %}{% endblock %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,10 +1,17 @@
 {% extends "base.html" %}
 {% block content %}
-<h1>Welcome to Astraion Travel</h1>
-<p>Use the navigation to manage clients, trips, and bookings.</p>
-<ul>
-  <li><a href="/clients">Clients</a></li>
-  <li><a href="/trips">Trips</a></li>
-  <li><a href="/bookings">Bookings</a></li>
-</ul>
+<section class="hero">
+  <h1>Discover Your Path</h1>
+  <p>Plan journeys for growth, adventure, and serenity.</p>
+  <a class="btn" href="/trips">Explore Trips</a>
+</section>
+
+<div class="card">
+  <h2>Manage</h2>
+  <ul>
+    <li><a href="/clients">Clients</a></li>
+    <li><a href="/trips">Trips</a></li>
+    <li><a href="/bookings">Bookings</a></li>
+  </ul>
+</div>
 {% endblock %}

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,14 +1,140 @@
+/* Astraion Travel core styles */
+/* Color palette */
+:root {
+  --color-deep-blue: #0a3d62;
+  --color-teal: #1abc9c;
+  --color-sand: #f4d8a4;
+  --color-text-dark: #2c3e50;
+}
+
 body {
-    font-family: Arial, sans-serif;
-    margin: 2rem;
+  margin: 0;
+  font-family: Helvetica, Arial, sans-serif;
+  background: var(--color-sand);
+  color: var(--color-text-dark);
 }
 
-:root{
-  --brand-deep-blue: #0c2a4d;
-  --brand-teal:      #1aa3a3;
-  --brand-sand:      #e9d7b7;
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1rem;
 }
 
-.header, .navbar { background: var(--brand-deep-blue); }
-.btn-primary     { background: var(--brand-teal); }
-.card            { border-radius: 12px; }
+header {
+  background: var(--color-deep-blue);
+  color: #fff;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.nav .logo {
+  font-size: 1.5rem;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #fff;
+  text-decoration: none;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.nav-links form {
+  margin: 0;
+}
+
+.nav a {
+  color: #fff;
+  text-decoration: none;
+  margin-right: 1rem;
+}
+
+.nav a:hover {
+  color: var(--color-teal);
+}
+
+main {
+  padding-top: 2rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.hero {
+  background: var(--color-deep-blue);
+  color: #fff;
+  border-radius: 12px;
+  padding: 4rem 2rem;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" stroke="%231abc9c" fill="none" stroke-width="1"><path d="M50 10 L58 30 L80 30 L62 45 L70 70 L50 55 L30 70 L38 45 L20 30 L42 30 Z"/></svg>');
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 40%;
+  opacity: 0.1;
+}
+
+.btn {
+  display: inline-block;
+  background: var(--color-teal);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.btn:hover {
+  background: #17a589;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+input,
+select {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+}
+
+.icon {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  background-size: contain;
+  background-repeat: no-repeat;
+}
+
+.icon-compass {
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="%23ffffff" fill="none" stroke-width="2"><circle cx="12" cy="12" r="10"/><polygon points="12,7 14,13 8,11"/></svg>');
+}
+
+.icon-map {
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="%23ffffff" fill="none" stroke-width="2"><polyline points="3 6 9 3 15 6 21 3 21 18 15 21 9 18 3 21 3 6"/></svg>');
+}
+


### PR DESCRIPTION
## Summary
- revamp base and home templates with Astraion Travel branding
- introduce global stylesheet with deep blue, teal, sand palette and icon motifs
- add login and role-specific dashboard templates for clients, agents, and the CEO

## Testing
- `pre-commit run --files static/css/app.css app/templates/base.html app/templates/home.html app/templates/auth/login.html app/templates/auth/client_dashboard.html app/templates/auth/agent_dashboard.html app/templates/auth/ceo_dashboard.html` *(fails: command not found)*
- `pip install pre-commit` *(fails: ProxyError - tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: 12 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68acd41fe9a883309ba84f54dc4d1770