### PR TITLE
Add DOB search and display for clients

### DIFF
--- a/app/templates/clients/list.html
+++ b/app/templates/clients/list.html
@@ -6,9 +6,10 @@
     <div class="toolbar">
       <form method="get">
         <input name="q" value="{{ q }}" class="input" placeholder="Search">
+        <input name="dob_q" value="{{ dob_q }}" class="input" placeholder="DOB (DD-MM or DD-MM-YYYY)">
       </form>
       <a href="/clients" class="btn ghost">Clear</a>
-      <a href="/clients?q={{ q }}&export=1" class="btn ghost">Export CSV</a>
+      <a href="/clients?q={{ q }}&dob_q={{ dob_q }}&export=1" class="btn ghost">Export CSV</a>
       <a href="/clients/new" class="btn primary">New Client</a>
     </div>
   </div>
@@ -28,7 +29,7 @@
         <td><a href="/clients/{{ c.id }}">{{ c.first_name }} {{ c.last_name }}</a></td>
         <td>{{ c.email or "" }}</td>
         <td>{{ c.phone or "" }}</td>
-        <td>{{ c.dob or "" }}</td>
+        <td>{{ c.dob.strftime('%d-%m-%Y') if c.dob else "—" }}</td>
         <td>{{ c.created_at }}</td>
       </tr>
       {% else %}


### PR DESCRIPTION
## Summary
- Display DOB in DD-MM-YYYY format or em dash when missing
- Support optional `dob_q` query parameter for exact or day-month DOB filtering
- Update client list page with DOB search input

## Testing
- `pytest` *(fails: ValidationError for ClientCreate and others)*

------
https://chatgpt.com/codex/tasks/task_e_68adbcb4b6d8833082dc0e48f08f7942