### PR TITLE
Revamp navigation and table styling

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,15 +10,23 @@
 <body>
   <header class="appbar">
     <div class="container">
-      <nav class="nav">
-        <a href="/">Astration Travel</a>
-        <div class="nav">
-          <a href="/" class="{% if request.url.path == '/' %}active{% endif %}">Home</a>
+      <div class="nav">
+        <div class="nav-left">
+          <a href="/" class="logo">Astraion Travel</a>
+        </div>
+        <nav class="nav-center">
           <a href="/clients" class="{% if request.url.path.startswith('/clients') %}active{% endif %}">Clients</a>
           <a href="/trips" class="{% if request.url.path.startswith('/trips') %}active{% endif %}">Trips</a>
           <a href="/bookings" class="{% if request.url.path.startswith('/bookings') %}active{% endif %}">Bookings</a>
+          <a href="/reports" class="{% if request.url.path.startswith('/reports') %}active{% endif %}">Reports</a>
+        </nav>
+        <div class="nav-right">
+          <form action="/search" method="get">
+            <input name="q" class="input" placeholder="Search" />
+          </form>
+          <a href="#" class="account">Account</a>
         </div>
-      </nav>
+      </div>
     </div>
   </header>
   <main>

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -26,13 +26,19 @@ a:hover{text-decoration:underline}
 .grid.cols-2{grid-template-columns:1fr 1fr;}
 .table{width:100%; border-collapse:separate; border-spacing:0; background:var(--card); border-radius:var(--radius); overflow:hidden; box-shadow:var(--shadow);}
 .table th, .table td{padding:10px 12px; border-bottom:1px solid var(--line);}
-.table th{background:#f8fafc; text-align:left; font-weight:600; color:var(--ink-soft); position:sticky; top:0;}
-.table tr:hover td{background:#fdfdfd}
+.table th{background:var(--bg); color:#fff; text-align:left; font-weight:600; position:sticky; top:0;}
+.table tbody tr:nth-child(even) td{background-color:rgba(233,220,199,0.3);}
+.table tbody tr:hover td{background-color:rgba(43,187,173,0.1);}
 .muted{color:var(--muted)}
 .kpi{display:flex; gap:16px; flex-wrap:wrap; margin-bottom:12px;}
 .kpi .pill{background:var(--sand); padding:8px 10px; border-radius:999px;}
-header.appbar{background:var(--bg); color:#fff; padding:10px 0;}
-header .nav{display:flex; gap:16px; align-items:center;}
-header .nav a{color:#cfe6ff}
-header .nav a.active{color:#fff; font-weight:600; border-bottom:2px solid var(--teal);}
+header.appbar{background:var(--bg); color:#fff; padding:10px 0; position:sticky; top:0; z-index:100;}
+header .nav{display:flex; align-items:center; justify-content:space-between; gap:16px;}
+header .nav-left, header .nav-center, header .nav-right{display:flex; align-items:center; gap:16px;}
+header .nav-center a{color:#cfe6ff;}
+header .nav-center a:hover{border-bottom:2px solid var(--teal);}
+header .nav-center a.active{color:#fff; font-weight:600; border-bottom:2px solid var(--teal);}
+header .nav-right form{margin:0;}
+header .nav-right .input{padding:6px 8px; border-radius:8px; border:none;}
+header .nav-right a{color:#cfe6ff;}
 .alert{background:#ffe5e5; color:#b71c1c; padding:var(--pad); border-radius:var(--radius); margin-bottom:var(--pad);}


### PR DESCRIPTION
## Summary
- Introduce flexible top navigation with left logo, centered links, and right search/account slot
- Style tables with deep-blue headers, alternating rows, and teal hover highlight

## Testing
- `pytest` *(fails: ValidationError and missing schemas)*

------
https://chatgpt.com/codex/tasks/task_e_68aea2633b948330a118f67f93cef9b2