### PR TITLE
feat: add upcoming/past tabs for trips

### DIFF
--- a/app/templates/trips/list.html
+++ b/app/templates/trips/list.html
@@ -5,28 +5,38 @@
     <h1>Trips</h1>
     <a href="/trips/new" class="btn primary">New Trip</a>
   </div>
-  {% set show_bookings = trips|length > 0 and trips[0].bookings is not none %}
+
+  <div class="tabs">
+    <a href="/trips?tab=upcoming" class="{% if tab != 'past' %}active{% endif %}">Upcoming</a>
+    <a href="/trips?tab=past" class="{% if tab == 'past' %}active{% endif %}">Past</a>
+  </div>
+
+  {% if tab == 'past' %}
+    {% set trips = past %}
+  {% else %}
+    {% set trips = upcoming %}
+  {% endif %}
+
   <table class="table">
     <thead>
       <tr>
         <th>Name</th>
-        <th>Created</th>
-        <th>Updated</th>
-        {% if show_bookings %}<th>#Bookings</th>{% endif %}
+        <th>Start</th>
+        <th>End</th>
       </tr>
     </thead>
     <tbody>
       {% for t in trips %}
-      <tr>
-        <td><a href="/trips/{{ t.id }}">{{ t.name }}</a></td>
-        <td>{{ t.created_at }}</td>
-        <td>{{ t.updated_at }}</td>
-        {% if show_bookings %}<td>{{ t.bookings|length }}</td>{% endif %}
+      <tr class="{% if tab == 'past' %}row-muted{% endif %}">
+        <td><a href="/trips/{{ t.id }}">{{ t.name }}</a> <span class="badge">{{ t.bookings|length }}</span></td>
+        <td>{{ t.start_date or '' }}</td>
+        <td>{{ t.end_date or '' }}</td>
       </tr>
       {% else %}
-      <tr><td colspan="{{ 3 + (1 if show_bookings else 0) }}">No trips yet.</td></tr>
+      <tr><td colspan="3">No trips yet.</td></tr>
       {% endfor %}
     </tbody>
   </table>
 </div>
 {% endblock %}
+

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -42,3 +42,10 @@ header .nav-right form{margin:0;}
 header .nav-right .input{padding:6px 8px; border-radius:8px; border:none;}
 header .nav-right a{color:#cfe6ff;}
 .alert{background:#ffe5e5; color:#b71c1c; padding:var(--pad); border-radius:var(--radius); margin-bottom:var(--pad);}
+
+.tabs{display:flex; gap:8px; border-bottom:1px solid var(--line); margin-bottom:12px;}
+.tabs a{padding:8px 12px; border:1px solid var(--line); border-bottom:none; border-radius:8px 8px 0 0; background:#f7f9fc; color:var(--ink);}
+.tabs a.active{background:var(--card); font-weight:600;}
+.badge{background:var(--bg); color:#fff; padding:2px 6px; border-radius:999px; font-size:12px; margin-left:4px;}
+.text-muted{color:var(--muted);}
+.row-muted td, .row-muted td a{color:var(--muted);}


### PR DESCRIPTION
## Summary
- split trips into Upcoming and Past tabs with default Upcoming
- show PAX badge and greyed Past entries
- add styles for tabs and muted rows

## Testing
- `pytest` *(fails: pydantic validation errors and missing schema classes)*

------
https://chatgpt.com/codex/tasks/task_e_68af3642f8a483308da68ce6990d170d